### PR TITLE
Do not auto register the Module sub namespace as a service

### DIFF
--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -20,4 +20,4 @@ services:
 
   Fipps\ColorattributeBundle\:
     resource: '../../*'
-    exclude: '../../{Resources,Entity,Repository,DependencyInjection,ContaoManager}/*'
+    exclude: '../../{Resources,Entity,Repository,DependencyInjection,ContaoManager,Module}/*'


### PR DESCRIPTION
Classes that are not supposed to be services should not be loaded as such. Possibly other sub namespaces are affected as well.